### PR TITLE
[FEAT] 포스팅뷰 텍스트뷰 상세 기능 구현

### DIFF
--- a/Melon-iOS/Info.plist
+++ b/Melon-iOS/Info.plist
@@ -28,7 +28,7 @@
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
+					<string>Posting</string>
 					<key>UIUserInterfaceStyle</key>
 					<string>Dark</string>
 				</dict>

--- a/Melon-iOS/Resource/Storyboard/Posting.storyboard
+++ b/Melon-iOS/Resource/Storyboard/Posting.storyboard
@@ -196,6 +196,7 @@
                         <outlet property="applyButton" destination="5LR-aZ-kn2" id="e0d-m4-Ac8"/>
                         <outlet property="cancelButton" destination="mV1-gS-tgw" id="8Ls-YK-dR5"/>
                         <outlet property="commentTextView" destination="pV3-Tr-cdf" id="Dyf-y8-hKH"/>
+                        <outlet property="wordCountLabel" destination="Saq-YB-Yph" id="5EZ-jG-XZc"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/Melon-iOS/Resource/Storyboard/Posting.storyboard
+++ b/Melon-iOS/Resource/Storyboard/Posting.storyboard
@@ -35,6 +35,9 @@
                                         <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="16"/>
                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                         <state key="normal" title="취소"/>
+                                        <connections>
+                                            <action selector="cancelButtonDidTap:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="4eB-Ts-wJA"/>
+                                        </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="글쓰기" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g6n-8w-jAg">
                                         <rect key="frame" x="178" y="13" width="52" height="24"/>
@@ -49,6 +52,9 @@
                                         <state key="normal" title="등록">
                                             <color key="titleColor" name="12MelonGray"/>
                                         </state>
+                                        <connections>
+                                            <action selector="applyButtonDidTap:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="AGA-vC-tAy"/>
+                                        </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Xih-yH-aOY">
                                         <rect key="frame" x="216" y="5" width="51" height="40"/>
@@ -187,6 +193,11 @@
                     </view>
                     <tabBarItem key="tabBarItem" title="Item" image="globe.europe.africa.fill" catalog="system" id="DE4-YK-cYp"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="applyButton" destination="5LR-aZ-kn2" id="e0d-m4-Ac8"/>
+                        <outlet property="cancelButton" destination="mV1-gS-tgw" id="8Ls-YK-dR5"/>
+                        <outlet property="commentTextView" destination="pV3-Tr-cdf" id="Dyf-y8-hKH"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Melon-iOS/Resource/Storyboard/Posting.storyboard
+++ b/Melon-iOS/Resource/Storyboard/Posting.storyboard
@@ -85,9 +85,8 @@
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="pV3-Tr-cdf">
                                 <rect key="frame" x="0.0" y="104" width="414" height="509"/>
                                 <color key="backgroundColor" name="12MelonDarkgray"/>
-                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
-                                <color key="textColor" name="12MelonWhite"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" name="12MelonGray"/>
+                                <fontDescription key="fontDescription" name="Pretendard-Regular" family="Pretendard" pointSize="15"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iHy-54-mR3">

--- a/Melon-iOS/Source/Screen/Posting/PostingVC.swift
+++ b/Melon-iOS/Source/Screen/Posting/PostingVC.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class PostingVC: UIViewController {
     
+    let placeholder = "24시간 이내 스트리밍 감상한 곡에 한하여 작성하신 댓글에 감상 여부가 표기 됩니다.\n감상 후 24시간이 지난 경우, 또는 내부 서비스 환경에 따라 감상 여부의 표기가 안될 수 있습니다."
     
     @IBOutlet weak var cancelButton: UIButton!
     @IBOutlet weak var applyButton: UIButton!
@@ -22,10 +23,40 @@ class PostingVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setCommentTextView()
+        setDelegate()
     }
     
     func setCommentTextView() {
+        commentTextView.text = placeholder
+        commentTextView.textColor = UIColor.gray
         commentTextView.textContainerInset = UIEdgeInsets(top: 16,left: 25,bottom: 16,right: 33)
     }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
+    }
+    
+    func setDelegate(){
+        commentTextView.delegate = self
+    }
 
+}
+
+extension PostingVC: UITextViewDelegate{
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            commentTextView.textColor = UIColor.gray
+        }else if textView.text == placeholder {
+            commentTextView.textColor = UIColor.white
+            commentTextView.text = nil
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            commentTextView.textColor = UIColor.gray
+            commentTextView.text = placeholder
+        }
+    }
+    
 }

--- a/Melon-iOS/Source/Screen/Posting/PostingVC.swift
+++ b/Melon-iOS/Source/Screen/Posting/PostingVC.swift
@@ -8,22 +8,24 @@
 import UIKit
 
 class PostingVC: UIViewController {
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+    
+    
+    @IBOutlet weak var cancelButton: UIButton!
+    @IBOutlet weak var applyButton: UIButton!
+    @IBOutlet weak var commentTextView: UITextView!
+    
+    @IBAction func cancelButtonDidTap(_ sender: Any) {
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    @IBAction func applyButtonDidTap(_ sender: Any) {
     }
-    */
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setCommentTextView()
+    }
+    
+    func setCommentTextView() {
+        commentTextView.textContainerInset = UIEdgeInsets(top: 16,left: 25,bottom: 16,right: 33)
+    }
 
 }

--- a/Melon-iOS/Source/Screen/Posting/PostingVC.swift
+++ b/Melon-iOS/Source/Screen/Posting/PostingVC.swift
@@ -31,6 +31,7 @@ class PostingVC: UIViewController {
         commentTextView.text = placeholder
         commentTextView.textColor = UIColor.gray
         commentTextView.textContainerInset = UIEdgeInsets(top: 16,left: 25,bottom: 16,right: 33)
+        commentTextView.tintColor = UIColor.green1
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {

--- a/Melon-iOS/Source/Screen/Posting/PostingVC.swift
+++ b/Melon-iOS/Source/Screen/Posting/PostingVC.swift
@@ -15,6 +15,7 @@ class PostingVC: UIViewController {
     @IBOutlet weak var applyButton: UIButton!
     @IBOutlet weak var commentTextView: UITextView!
     
+    @IBOutlet weak var wordCountLabel: UILabel!
     @IBAction func cancelButtonDidTap(_ sender: Any) {
     }
     
@@ -59,4 +60,12 @@ extension PostingVC: UITextViewDelegate{
         }
     }
     
+    func textViewDidChange(_ textView: UITextView) {
+        if commentTextView.text.count > 1000 {
+           commentTextView.deleteBackward()
+        }
+        
+        wordCountLabel.text = "\(commentTextView.text.count) / 1000"
+    }
+
 }

--- a/Melon-iOS/Source/Screen/Posting/PostingVC.swift
+++ b/Melon-iOS/Source/Screen/Posting/PostingVC.swift
@@ -23,15 +23,18 @@ class PostingVC: UIViewController {
     }
     override func viewDidLoad() {
         super.viewDidLoad()
-        setCommentTextView()
+        setUI()
         setDelegate()
     }
     
-    func setCommentTextView() {
+    func setUI() {
         commentTextView.text = placeholder
         commentTextView.textColor = UIColor.gray
         commentTextView.textContainerInset = UIEdgeInsets(top: 16,left: 25,bottom: 16,right: 33)
         commentTextView.tintColor = UIColor.green1
+        
+        applyButton.titleLabel?.textColor = UIColor.gray
+        applyButton.isEnabled = false
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -52,7 +55,10 @@ extension PostingVC: UITextViewDelegate{
             commentTextView.textColor = UIColor.white
             commentTextView.text = nil
         }
+        
     }
+    
+    
     
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.isEmpty {
@@ -67,6 +73,14 @@ extension PostingVC: UITextViewDelegate{
         }
         
         wordCountLabel.text = "\(commentTextView.text.count) / 1000"
+        
+        if commentTextView.text !=  ""{
+            applyButton.titleLabel?.textColor = UIColor.green1
+            applyButton.isUserInteractionEnabled = true
+        }else {
+            applyButton.titleLabel?.textColor = UIColor.gray
+            applyButton.isUserInteractionEnabled = false
+        }
     }
 
 }


### PR DESCRIPTION
## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 텍스트뷰 padding 조정하기
- 텍스트뷰 글자 입력시 하단의 글자수 업데이트 되도록하기
- 1000자넘어가면 입력 못하게 막기
- 텍스트뷰 플레이스홀더 설정하기
- 텍스트뷰 비어있지 않을 시에 상단의 버튼 초록색으로 활성화 되도록하기
- 텍스트뷰 커서색깔 바꾸기

## 🌱 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->



## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->


https://user-images.githubusercontent.com/51031771/171333862-efdfd5bd-ac12-430d-b13d-24e59908d3b2.mov


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #7 
